### PR TITLE
chore(refactor): silence `orm_mode` warning

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -12,7 +12,7 @@ class ContactSchema(BaseModel):
     marketing_opt_in: bool = False
 
     class Config:
-        orm_mode = True
+        from_attributes = True
 
 
 class UserSchema(BaseModel):
@@ -24,7 +24,7 @@ class UserSchema(BaseModel):
     department: str
 
     class Config:
-        orm_mode = True
+        from_attributes = True
 
 
 class CompanySchema(BaseModel):
@@ -33,4 +33,4 @@ class CompanySchema(BaseModel):
     contacts: List[ContactSchema]
 
     class Config:
-        orm_mode = True
+        from_attributes = True


### PR DESCRIPTION

#### Description

When running the demo, I was getting a warning from Pydanticsaying that `orm_mode` as a config key has changed in v2. Setting this to `from_attributes` resolves the issue.

Ref: https://docs.pydantic.dev/latest/migration/#changes-to-pydanticbasemodel

Issue https://github.com/cerbos/python-sqlalchemy-cerbos/issues/5

#### Checklist 

<!-- See https://github.com/cerbos/cerbos/blob/main/CONTRIBUTING.md#submitting-pull-requests for more information. -->

- [x] The PR title has the correct prefix 
- [x] PR is linked to the corresponding issue
- [x] All commits are signed-off (`git commit -s ...`) to provide the [DCO](https://developercertificate.org/)
